### PR TITLE
Fix: Standardize species naming convention

### DIFF
--- a/app/api/v1/models/models.py
+++ b/app/api/v1/models/models.py
@@ -71,14 +71,14 @@ class Pet(Base):
 class Species(Base):
     __tablename__ = "species"
 
-    specie_id = Column(Integer, primary_key=True, index=True)
-    specie_name = Column(String(20), nullable=False)
-    specie_description = Column(String(60), nullable=False)
+    species_id = Column(Integer, primary_key=True, index=True)
+    species_name = Column(String(20), nullable=False)
+    species_description = Column(String(60), nullable=False)
     created_at = Column(Date, server_default=func.now())
     updated_at = Column(Date, server_default=func.now(), onupdate=func.now())
 
     def __repr__(self):
-        return f"<Species(specie_id={self.specie_id}, specie_name={self.specie_name}, specie_description={self.specie_description}, created_at={self.created_at}, updated_at={self.updated_at})>"
+        return f"<Species(species_id={self.species_id}, species_name={self.species_name}, species_description={self.species_description}, created_at={self.created_at}, updated_at={self.updated_at})>"
 
 
 class Size(Base):

--- a/app/db/tailsofjoy.sql
+++ b/app/db/tailsofjoy.sql
@@ -57,12 +57,12 @@ CREATE TABLE `breeds` (
 );
 
 CREATE TABLE `species` (
-	`specie_id` INT NOT NULL AUTO_INCREMENT,
-	`specie_name` varchar(20) NOT NULL,
-	`specie_description` varchar(60) NOT NULL,
+	`species_id` INT NOT NULL AUTO_INCREMENT,
+	`species_name` varchar(20) NOT NULL,
+	`species_description` varchar(60) NOT NULL,
 	`created_at` TIMESTAMP NOT NULL DEFAULT current_timestamp(),
 	`updated_at` TIMESTAMP NOT NULL DEFAULT current_timestamp() ON UPDATE current_timestamp(),
-	PRIMARY KEY (`specie_id`)
+	PRIMARY KEY (`species_id`)
 );
 
 CREATE TABLE `sizes` (
@@ -75,7 +75,7 @@ CREATE TABLE `sizes` (
 
 ALTER TABLE `pets` ADD CONSTRAINT `pets_fk0` FOREIGN KEY (`registered_by`) REFERENCES `users`(`user_id`);
 
-ALTER TABLE `pets` ADD CONSTRAINT `pets_fk1` FOREIGN KEY (`species_id`) REFERENCES `species`(`specie_id`);
+ALTER TABLE `pets` ADD CONSTRAINT `pets_fk1` FOREIGN KEY (`species_id`) REFERENCES `species`(`species_id`);
 
 ALTER TABLE `pets` ADD CONSTRAINT `pets_fk2` FOREIGN KEY (`breed_id`) REFERENCES `breeds`(`breed_id`);
 


### PR DESCRIPTION
Corrected inconsistencies in column and variable names related to "species" throughout the codebase and database schema. This ensures better readability and maintainability by adhering to a unified naming standard.